### PR TITLE
Method support for PHPhinder\Property on Schema generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,18 @@ class Book
     private ?string $title = null;
 
     #[ORM\Column(type: Types::SIMPLE_ARRAY)]
-    #[PHPhinder\Property(Schema::IS_INDEXED | Schema::IS_REQUIRED)]
     private array $authors = [];
 
     #[ORM\Column(type: Types::TEXT)]
     #[PHPhinder\Property(Schema::IS_INDEXED)]
     private ?string $description = null;
 ...
+    
+    #[PHPhinder\Property(Schema::IS_INDEXED | Schema::IS_REQUIRED, name: 'authors')]
+    public function getAuthorsCsv(): string
+    {
+        return implode(', ', $this->authors);
+    }}
 ```
 
 ### Controller
@@ -69,7 +74,7 @@ On the controller side we'll need to configure the Search engine to look for `Bo
 
 ```
 
-Then, in the actions, we can get results with one simgle method:
+Then, in the actions, we can get results with one single method:
 
 ```php
     #[Route('/search', name: 'app_search', methods: ['GET', 'POST'])]

--- a/src/Schema/Attribute/Property.php
+++ b/src/Schema/Attribute/Property.php
@@ -3,9 +3,9 @@ namespace PHPhinderBundle\Schema\Attribute;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[Attribute(Attribute::TARGET_PROPERTY|Attribute::TARGET_METHOD)]
 class Property
 {
-    public function __construct(public readonly int $flags)
+    public function __construct(public readonly int $flags, public readonly ?string $name = null)
     {}
 }

--- a/src/Serializer/PropertyAttributeSerializer.php
+++ b/src/Serializer/PropertyAttributeSerializer.php
@@ -18,10 +18,22 @@ class PropertyAttributeSerializer
             if (!empty($propertyAttributes)) {
                 $property->setAccessible(true);
                 $value = $property->getValue($entity);
-                $field = $property->getName();
+                $field = $propertyAttributes->name ?? $property->getName();
                 $serializedData[$field === 'id' ? '_id' : $field] = $value;
             }
         }
+
+        foreach ($reflectionClass->getMethods() as $method) {
+            $propertyAttributes = $method->getAttributes(Property::class);
+
+            if (!empty($propertyAttributes)) {
+                $arguments = $propertyAttributes[0]->getArguments();
+                $value = $method->invoke($entity);
+                $field = $arguments['name'] ?? $method->getName();
+                $serializedData[$field === 'id' ? '_id' : $field] = $value;
+            }
+        }
+
         return $serializedData;
     }
 }


### PR DESCRIPTION
With this change, you can also use methods on entities as Schema properties. 

```php
    #[PHPhinder\Property(Schema::IS_INDEXED | Schema::IS_REQUIRED, name: 'authors')]
    public function getAuthorsCsv(): ?string
    {
        return implode(', ', $this->authors);
    }
```